### PR TITLE
Install jupyterlab before npm build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ name = "yjs-widgets"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.7"
-dependencies = []
+dependencies = [
+    "jupyterlab>=4.0.0,<5"
+]
 classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,7 @@ name = "yjs-widgets"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.7"
-dependencies = [
-    "jupyterlab>=4.0.0,<5"
-]
+dependencies = []
 classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
@@ -73,6 +71,7 @@ version-cmd = "hatch version"
 
 [tool.jupyter-releaser.hooks]
 before-build-npm = [
+    "python -m pip install 'jupyterlab>=4.0.0,<5'",
     "jlpm",
     "jlpm build:prod",
 ]


### PR DESCRIPTION
`check_release` [failed](https://github.com/QuantStack/yjs-widgets/actions/runs/11465694829/job/31904714205) because `jlpm` could not be found, and since `yjs-widgets` is a JupyterLab extension it seems reasonable to add it as a dependency.