### PR TITLE
Add a dispose method to `IJupyterYWidget`

### DIFF
--- a/src/notebookrenderer/model.ts
+++ b/src/notebookrenderer/model.ts
@@ -1,7 +1,7 @@
 import { IDisposable } from '@lumino/disposable';
 
 import { IJupyterYModel } from '../types';
-import { IJupyterYWidgetManager } from './types';
+import { IJupyterYWidget, IJupyterYWidgetManager } from './types';
 
 export class NotebookRendererModel implements IDisposable {
   constructor(options: NotebookRendererModel.IOptions) {
@@ -26,14 +26,19 @@ export class NotebookRendererModel implements IDisposable {
     }
   }
 
-  createYWidget(commId: string, node: HTMLElement): void {
+  createYWidget(
+    commId: string,
+    node: HTMLElement
+  ): IJupyterYWidget | undefined {
     if (this._kernelId) {
       const yModel = this._widgetManager.getWidgetModel(this._kernelId, commId);
       if (yModel) {
         const widgetFactory = this._widgetManager.getWidgetFactory(
           yModel.yModelName
         );
-        new widgetFactory(yModel, node);
+        if (widgetFactory) {
+          return new widgetFactory(yModel, node);
+        }
       }
     }
   }

--- a/src/notebookrenderer/types.ts
+++ b/src/notebookrenderer/types.ts
@@ -22,7 +22,7 @@ export interface IJupyterYWidgetManager {
     yWidgetFactory: IJupyterYWidgetFactory
   ): void;
   getWidgetModel(kernelId: string, commId: string): IJupyterYModel | undefined;
-  getWidgetFactory(modelName: string): any | undefined;
+  getWidgetFactory(modelName: string): IJupyterYWidgetFactory | undefined;
 }
 
 export const IJupyterYWidgetManager = new Token<IJupyterYWidgetManager>(
@@ -33,4 +33,5 @@ export const IJupyterYWidgetManager = new Token<IJupyterYWidgetManager>(
 export interface IJupyterYWidget {
   node: HTMLElement;
   yModel: IJupyterYModel;
+  dispose?(): void;
 }

--- a/src/notebookrenderer/view.ts
+++ b/src/notebookrenderer/view.ts
@@ -4,6 +4,7 @@ import { Widget } from '@lumino/widgets';
 import { NotebookRendererModel } from './model';
 import { IRenderMime } from '@jupyterlab/rendermime';
 import { IJupyterYModel } from '../types';
+import { IJupyterYWidget } from './types';
 
 export const CLASS_NAME = 'mimerenderer-jupyterywidget';
 
@@ -22,6 +23,7 @@ export class JupyterYWidget extends Widget implements IRenderMime.IRenderer {
   }
 
   dispose(): void {
+    this._ywidget?.dispose?.();
     if (this.isDisposed) {
       return;
     }
@@ -35,10 +37,11 @@ export class JupyterYWidget extends Widget implements IRenderMime.IRenderer {
     if (!this._yModel) {
       return;
     }
-    this._modelFactory.createYWidget(modelId, this.node);
+    this._ywidget = this._modelFactory.createYWidget(modelId, this.node);
   }
 
   private _modelFactory: NotebookRendererModel;
   private _mimeType: string;
   private _yModel?: IJupyterYModel;
+  private _ywidget?: IJupyterYWidget;
 }

--- a/src/notebookrenderer/widgetManager.ts
+++ b/src/notebookrenderer/widgetManager.ts
@@ -34,7 +34,7 @@ export class JupyterYWidgetManager implements IJupyterYWidgetManager {
     return this._registry.get(kernelId)?.getModel(commId);
   }
 
-  getWidgetFactory(modelName: string) {
+  getWidgetFactory(modelName: string): IJupyterYWidgetFactory | undefined {
     return this._yWidgetFactories.get(modelName);
   }
 


### PR DESCRIPTION
Call a 'dispose()' method of the widget when the view is disposed (notebook closed or cell output cleared).